### PR TITLE
don't make course zipfile

### DIFF
--- a/.github/workflows/bookdown.yaml
+++ b/.github/workflows/bookdown.yaml
@@ -48,11 +48,11 @@ jobs:
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
         run: Rscript make_course_zip.R
 
-      - name: commit course zip
-        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-        run: |
-          if [[ -n "$(git status --porcelain)" ]]; then
-            git add intro-r-Feb2022/. intro-r-Feb2022.zip
-            git commit -m 'make course zipfile'
-            git push https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git HEAD:${{ github.ref }}
-          fi
+      # - name: commit course zip
+      #   if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+      #   run: |
+      #     if [[ -n "$(git status --porcelain)" ]]; then
+      #       git add intro-r-Feb2022/. intro-r-Feb2022.zip
+      #       git commit -m 'make course zipfile'
+      #       git push https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git HEAD:${{ github.ref }}
+      #     fi


### PR DESCRIPTION
I think having the zip created every time we make a commit could eventually lead to some issues. This way the zip is created but not committed. Once we are finished with content we can turn this back on?